### PR TITLE
SDQ-1671: Reverting administrative state filtering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,6 +220,10 @@ Change History
     * Added Rx to Optical100Gig
     * Added SNR, FEC to Transponders
 
+* 1.16
+
+  * Removed checks for AdminState
+
 Known Issues
 ===========
 

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/AdvaMibTypes.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/AdvaMibTypes.py
@@ -1,21 +1,6 @@
 """
-Code translations for defined types in ADVA MIBs
+Code translations for defined types in ADVA-MIB
 """
-
-class AdminState:
-    """
-    http://www.circitor.fr/Mibs/Html/A/ADVA-FSPR7-TC-MIB.php#FspR7AdminState
-    Translations assisted by browsing the Adva FSP Network Manager client.
-    """
-    UNDEFINED = 0
-    UNASSIGNED = 1
-    IN_SERVICE = 2
-    AUTO_IN_SERVICE = 3
-    OUT_OF_SERVICE_MANAGEMENT = 4
-    OUT_OF_SERVICE_MAINTENANCE = 5
-    DISABLED = 6
-    PRE_POST_SERVICE = 7
-
 
 class AssignmentState:
     """

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
@@ -47,7 +47,7 @@ class FSP3000R7MibCommon(SnmpPlugin):
 
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsOPRModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
             containsOPRModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
@@ -109,11 +109,7 @@ class FSP3000R7MibCommon(SnmpPlugin):
                         )
                     )
 
-                    if not (entity_assigned or entity_equipped):
-                        log.info('Skipping %s, assigned=%s, equipped=%s',
-                                 entityTable[entityIndex]['entityIndexAid'],
-                                 entity_assigned,
-                                 entity_equipped)
+                    if not (entity_assigned and entity_equipped):
                         continue;
 
                     om = self.objectMap()
@@ -148,7 +144,6 @@ class FSP3000R7MibCommon(SnmpPlugin):
             if inventoryUnitName == model:
                 return True
         return False
-
 
     def __make_sort_key(self,entityIndexAid):
         """Return a string to sort on, e.g. 'MOD-1-3' -> '001003000000'

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
@@ -18,7 +18,6 @@ from Products.DataCollector.plugins.CollectorPlugin import SnmpPlugin, GetTableM
 from Products.DataCollector.plugins.DataMaps import ObjectMap
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7Channels import Channels
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibPickle import getCache
-from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import AdminState
 from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import AssignmentState
 from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import EquipmentState
 
@@ -93,11 +92,6 @@ class FSP3000R7MibCommon(SnmpPlugin):
                 # Now find sub-organizers that respond to OPR
                 if modName not in containsOPRModules:
                     continue
-
-                # Skip modules that are out of service
-                if not self._entity_is_in_service(modName, adminStateTable):
-                    continue
-
                 for entityIndex in containsOPRModules[modName]:
                     # skip non-production components
                     entity_assigned = (
@@ -115,7 +109,11 @@ class FSP3000R7MibCommon(SnmpPlugin):
                         )
                     )
 
-                    if not (entity_assigned and entity_equipped):
+                    if not (entity_assigned or entity_equipped):
+                        log.info('Skipping %s, assigned=%s, equipped=%s',
+                                 entityTable[entityIndex]['entityIndexAid'],
+                                 entity_assigned,
+                                 entity_equipped)
                         continue;
 
                     om = self.objectMap()
@@ -138,30 +136,6 @@ class FSP3000R7MibCommon(SnmpPlugin):
 
         return rm
 
-    def _entity_is_in_service(self, entityIndexAid, adminStateTable):
-        """
-        To be considered "in service", adminState must either be undefined,
-        non-existent, in service, or automatically in service. This seems to
-        only exist for module-level components like "MOD-2-2", "MOD-1-PSU10".
-        """
-        return self._get_admin_state(entityIndexAid, adminStateTable) in (
-            AdminState.UNDEFINED,
-            AdminState.AUTO_IN_SERVICE,
-            AdminState.IN_SERVICE,
-        )
-
-    def _get_admin_state(self, entityIndexAid, adminStateTable):
-        """
-        Since the table containing adminStatus uses a different indexing system,
-        use the entityEqptAidString to match the alternate index and return the
-        adminState if available.
-        """
-        for index, attributes in adminStateTable.items():
-            if entityIndexAid == attributes.get('entityEqptAidString'):
-                return attributes.get('moduleDefAdmin', AdminState.UNDEFINED)
-
-        return AdminState.UNDEFINED
-
     def __model_match(self,inventoryUnitName,componentModels):
         for model in componentModels:
             # Test different channel variations if there's a # on end
@@ -174,6 +148,7 @@ class FSP3000R7MibCommon(SnmpPlugin):
             if inventoryUnitName == model:
                 return True
         return False
+
 
     def __make_sort_key(self,entityIndexAid):
         """Return a string to sort on, e.g. 'MOD-1-3' -> '001003000000'

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibPickle.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibPickle.py
@@ -5,7 +5,7 @@ from pprint import pformat
 def getCache (deviceId, modelerName, log):
     cache_file_name = '/tmp/%s.Adva_inventory_SNMP.pickle' % deviceId
 
-    inventoryTable = entityTable = opticalIfDiagTable = adminStateTable = False
+    inventoryTable = entityTable = opticalIfDiagTable = False
     cache_file_time = 0
 
     bad_cache = 0
@@ -15,7 +15,6 @@ def getCache (deviceId, modelerName, log):
         inventoryTable = cPickle.load(cache_file)
         entityTable = cPickle.load(cache_file)
         opticalIfDiagTable = cPickle.load(cache_file)
-        adminStateTable = cPickle.load(cache_file)
         cache_file_time = cPickle.load(cache_file)
         cache_file.close()
     except IOError,cPickle.PickleError:
@@ -24,16 +23,16 @@ def getCache (deviceId, modelerName, log):
 
     if bad_cache or cache_file_time < time.time() - 900:
         log.warn("Cached SNMP doesn't exist or is older than 15 minutes. You must include the modeler plugin FSP3000R7Device")
-        return False, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
+        return False, inventoryTable, entityTable, opticalIfDiagTable, containsOPRModules
 
     if not inventoryTable:
         log.warn('No SNMP inventoryTable response from %s %s',
                  deviceId, modelerName)
-        return False, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
+        return False, inventoryTable, entityTable, opticalIfDiagTable, containsOPRModules
     if not entityTable:
         log.warn('No SNMP entityTable response from %s for the %s plugin',
                  deviceId, modelerName)
-        return False, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
+        return False, inventoryTable, entityTable, opticalIfDiagTable, containsOPRModules
     else:
         log.debug('SNMP entityTable and inventoryTable responses received')
     # not all modules will respond to opticalIfDiagTable so don't return False
@@ -77,7 +76,7 @@ def getCache (deviceId, modelerName, log):
                 else:
                     containsOPRModules[parentIndexAid].append(entityIndex)
 
-    return True, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
+    return True,inventoryTable,entityTable,opticalIfDiagTable,containsOPRModules
 
 
 def __get_parent(log,childIndex,entityTable):

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7RamanMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7RamanMib.py
@@ -48,7 +48,7 @@ class FSP3000R7RamanPortMib(SnmpPlugin):
         # cached data from device modeler
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsOPRModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
             containsOPRModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7DeviceMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7DeviceMib.py
@@ -54,8 +54,6 @@ class FSP3000R7DeviceMib(PythonPlugin):
         entityAssignmentStateOID = '1.3.6.1.4.1.2544.2.5.5.2.1.7'
         entityEquipmentStateOID = '1.3.6.1.4.1.2544.2.5.5.2.1.8'
         opticalIfDiagInputPowerOID = '1.3.6.1.4.1.2544.1.11.2.4.3.5.1.3'
-        entityEqptAidStringOID = '1.3.6.1.4.1.2544.1.11.7.2.2.1.6'
-        moduleDefAdminOID = '1.3.6.1.4.1.2544.1.11.10.3.3.7.1.26'
 
         getdata = {}
         
@@ -64,44 +62,22 @@ class FSP3000R7DeviceMib(PythonPlugin):
         self.__snmpget(device,neSwVersion,'setOSProductKey',getdata)
         log.info('Got software version %s' % getdata['setOSProductKey'])
 
-        # The "def" tables in ADVA-FSPR7-DEF-MIB uses different indexes to refer to the
-        # same entities. Match on entityEqptAidString == entityIndexAid when needed.
-        adminStateTable = {}
-        raw_adminState = {}
-        raw_adminState = self.__snmpgettable(device,moduleDefAdminOID)
-        self.__make_cacheable('moduleDefAdmin',
-                              moduleDefAdminOID,
-                              raw_adminState,
-                              adminStateTable)
-
-        raw_entityEqptAidString = {}
-        raw_entityEqptAidString = self.__snmpgettable(device,entityEqptAidStringOID)
-        self.__make_cacheable('entityEqptAidString',
-                              entityEqptAidStringOID,
-                              raw_entityEqptAidString,
-                              adminStateTable)
-
         inventoryTable = {}
         raw_inventory = {}
         raw_inventory = self.__snmpgettable(device,inventoryUnitNameOID)
-        self.__make_cacheable('inventoryUnitName',
-                              inventoryUnitNameOID,
-                              raw_inventory,
-                              inventoryTable)
+        self.__make_cacheable('inventoryUnitName',raw_inventory,inventoryTable)
         log.debug('inventoryTable: %s' % pformat(inventoryTable))
 
         entityTable = {}
         raw_entityContainedIn = {}
         raw_entityContainedIn = self.__snmpgettable(device,entityContainedInOID)
         self.__make_cacheable('entityContainedIn',
-                              entityContainedInOID,
                               raw_entityContainedIn,
                               entityTable)
 
         raw_entityIndexAid = {}
         raw_entityIndexAid = self.__snmpgettable(device,entityIndexAidOID)
         self.__make_cacheable('entityIndexAid',
-                              entityIndexAidOID,
                               raw_entityIndexAid,
                               entityTable)
 
@@ -109,7 +85,6 @@ class FSP3000R7DeviceMib(PythonPlugin):
         raw_interfaceConfigIdentifier = \
           self.__snmpgettable(device,interfaceConfigIdentifierOID)
         self.__make_cacheable('interfaceConfigIdentifier',
-                              interfaceConfigIdentifierOID,
                               raw_interfaceConfigIdentifier,
                               entityTable)
 
@@ -117,7 +92,6 @@ class FSP3000R7DeviceMib(PythonPlugin):
         raw_entityAssignmentState = self.__snmpgettable(device,
                                                        entityAssignmentStateOID)
         self.__make_cacheable('entityAssignmentState',
-                              entityAssignmentStateOID,
                               raw_entityAssignmentState,
                               entityTable)
 
@@ -125,7 +99,6 @@ class FSP3000R7DeviceMib(PythonPlugin):
         raw_entityEquipmentState = self.__snmpgettable(device,
                                                        entityEquipmentStateOID)
         self.__make_cacheable('entityEquipmentState',
-                              entityEquipmentStateOID,
                               raw_entityEquipmentState,
                               entityTable)
         log.debug('entityTable: %s' % pformat(entityTable))
@@ -135,7 +108,6 @@ class FSP3000R7DeviceMib(PythonPlugin):
         raw_opticalIfDiagInputPower= self.__snmpgettable(device,
                                                      opticalIfDiagInputPowerOID)
         self.__make_cacheable('opticalIfDiagInputPower',
-                              opticalIfDiagInputPowerOID,
                               raw_opticalIfDiagInputPower,
                               opticalIfDiagTable)
         # sometimes Avda shelves give bogus -65535 input power readings for
@@ -159,7 +131,6 @@ class FSP3000R7DeviceMib(PythonPlugin):
             cPickle.dump(inventoryTable,cache_file)
             cPickle.dump(entityTable,cache_file)
             cPickle.dump(opticalIfDiagTable,cache_file)
-            cPickle.dump(adminStateTable,cache_file)
             cPickle.dump(time.time(),cache_file)
             cache_file.close()
         except IOError,cPickle.PickleError:
@@ -212,14 +183,9 @@ class FSP3000R7DeviceMib(PythonPlugin):
         return results
 
 
-    def __make_cacheable(self,name,base_oid,raw,results):
-        """
-        Aggregate SNMP results by index.
-        Most indexes are simple integers, but some are dotted (123456789 vs. 123.456.789).
-        Find the index by simply removing the base OID and one dot.
-        """
+    def __make_cacheable(self,name,raw,results):
         for oid,val in raw.items():
-            index = oid.replace(base_oid + '.', '')
+            index = oid.split('.')[-1]
             if index not in results:
                 results[index] = {}
             results[index][name] = val

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7DeviceMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7DeviceMib.py
@@ -182,7 +182,12 @@ class FSP3000R7DeviceMib(PythonPlugin):
             pass
         return results
 
-
+    """
+    Compile SNMP results by index.
+    This assumes that the index is a single integer following a dot at the
+    end of an OID. If we need to compile indexes that contain dots themselves
+    (12.34.56 instead of just 123456), this method will need to be modified.
+    """
     def __make_cacheable(self,name,raw,results):
         for oid,val in raw.items():
             index = oid.split('.')[-1]

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
@@ -50,20 +50,22 @@ class FSP3000R7ModuleMib(SnmpPlugin):
         rm = self.relMap()
 
         # pick up MOD-* containers from entityTable
-        for entityIndex in entityTable:
+        for entityIndex, attributes in entityTable.items():
             # Power Supply, NCU and Fan models are already top level containers
-            if not (entityIndex in inventoryTable):
+            if entityIndex not in inventoryTable:
                 continue
             inventoryUnitName = inventoryTable[entityIndex]['inventoryUnitName']
             if inventoryUnitName in FanorNCUorPSModels:
                 continue
-            if entityTable[entityIndex]['entityIndexAid'].startswith('MOD-') or entityTable[entityIndex]['entityIndexAid'].startswith('MODC-'):
+
+            entityIndexAid = attributes['entityIndexAid']
+
+            if entityIndexAid.startswith('MOD-') or entityIndexAid.startswith('MODC-'):
                 om = self.objectMap()
                 om.EntityIndex = int(entityIndex)
                 om.inventoryUnitName = inventoryUnitName
-                om.entityIndexAid = entityTable[entityIndex]['entityIndexAid']
-                om.entityAssignmentState = \
-                    entityTable[entityIndex]['entityAssignmentState']
+                om.entityIndexAid = entityIndexAid
+                om.entityAssignmentState = attributes['entityAssignmentState']
                 om.interfaceConfigId     = ''
                 om.sortKey               = '000000000'
                 om.entityAssignmentState = 'Not set by modeler'

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
@@ -41,7 +41,7 @@ class FSP3000R7ModuleMib(FSP3000R7MibCommon):
 
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
             containsModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
@@ -7,7 +7,6 @@ Look for modules that contain amplifier stages, transponder optics. etc.
 from Products.DataCollector.plugins.CollectorPlugin import SnmpPlugin, GetTableMap, GetMap
 from Products.DataCollector.plugins.DataMaps import ObjectMap
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7Channels import Channels
-from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibCommon import FSP3000R7MibCommon
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibPickle import getCache
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FanModels import FanModels
 from ZenPacks.Merit.AdvaFSP3000R7.lib.NCUModels import NCUModels
@@ -18,7 +17,7 @@ FanorNCUorPSModels = [item for sublist in \
                           [FanModels,NCUModels,PowerSupplyModels]
                               for item in sublist]
 
-class FSP3000R7ModuleMib(FSP3000R7MibCommon):
+class FSP3000R7ModuleMib(SnmpPlugin):
 
     modname = "ZenPacks.Merit.AdvaFSP3000R7.FSP3000R7Module"
     relname = "FSP3000R7Mod"
@@ -51,25 +50,20 @@ class FSP3000R7ModuleMib(FSP3000R7MibCommon):
         rm = self.relMap()
 
         # pick up MOD-* containers from entityTable
-        for entityIndex, attributes in entityTable.items():
+        for entityIndex in entityTable:
             # Power Supply, NCU and Fan models are already top level containers
-            if entityIndex not in inventoryTable:
+            if not (entityIndex in inventoryTable):
                 continue
             inventoryUnitName = inventoryTable[entityIndex]['inventoryUnitName']
             if inventoryUnitName in FanorNCUorPSModels:
                 continue
-
-            # Skip module if out of service
-            entityIndexAid = attributes['entityIndexAid']
-            if not self._entity_is_in_service(entityIndexAid, adminStateTable):
-                continue
-
-            if entityIndexAid.startswith('MOD-') or entityIndexAid.startswith('MODC-'):
+            if entityTable[entityIndex]['entityIndexAid'].startswith('MOD-') or entityTable[entityIndex]['entityIndexAid'].startswith('MODC-'):
                 om = self.objectMap()
                 om.EntityIndex = int(entityIndex)
                 om.inventoryUnitName = inventoryUnitName
-                om.entityIndexAid = entityIndexAid
-                om.entityAssignmentState = attributes['entityAssignmentState']
+                om.entityIndexAid = entityTable[entityIndex]['entityIndexAid']
+                om.entityAssignmentState = \
+                    entityTable[entityIndex]['entityAssignmentState']
                 om.interfaceConfigId     = ''
                 om.sortKey               = '000000000'
                 om.entityAssignmentState = 'Not set by modeler'

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
@@ -19,7 +19,6 @@ from re import match
 from Products.DataCollector.plugins.CollectorPlugin import SnmpPlugin, GetTableMap, GetMap
 from Products.DataCollector.plugins.DataMaps import ObjectMap
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibPickle import getCache
-from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibCommon import FSP3000R7MibCommon
 from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import AssignmentState
 from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import EquipmentState
 
@@ -27,9 +26,8 @@ from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import EquipmentState
 # Use SNMP data from Device Modeler in a cache file.  Can't be a PythonPlugin
 # since those run before any SnmpPlugin; device modeler is an PythonPlugin so
 # the cache file will be created before this is run.
-# Need to override FSP3000R7MibCommon.process() since some Muxsponder OTU ports
-# don't respond to OPR.
-class FSP3000R7OTU100GMib(FSP3000R7MibCommon):
+# Can't use FSP3000R7MibCommon since Muxsponder OTU ports don't respond to OPR
+class FSP3000R7OTU100GMib(SnmpPlugin):
 
     modname = 'ZenPacks.Merit.AdvaFSP3000R7.FSP3000R7OTU100Gig'
     relname = 'FSP3000R7OTU100G'
@@ -73,12 +71,7 @@ class FSP3000R7OTU100GMib(FSP3000R7MibCommon):
             bladeIndexAid = entityTable[bladeEntityIndex]['entityIndexAid']
             if not bladeInv in componentModels:
                 continue
-
-            # Skip blade if out of service
-            if not self._entity_is_in_service(bladeIndexAid, adminStateTable):
-                continue
-
-            log.info('found 100G Muxponder OTU matching model %s in module %s', bladeInv, bladeIndexAid)
+            log.info('found 100G Muxponder OTU matching model %s' % bladeInv)
     
             # find ports from entityContainedIn for 100G OTU entityIndex
             ports = self.__findPorts(log,bladeEntityIndex,entityTable)

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
@@ -71,7 +71,8 @@ class FSP3000R7OTU100GMib(SnmpPlugin):
             bladeIndexAid = entityTable[bladeEntityIndex]['entityIndexAid']
             if not bladeInv in componentModels:
                 continue
-            log.info('found 100G Muxponder OTU matching model %s' % bladeInv)
+
+            log.info('found 100G Muxponder OTU matching model %s in module %s', bladeInv, bladeIndexAid)
     
             # find ports from entityContainedIn for 100G OTU entityIndex
             ports = self.__findPorts(log,bladeEntityIndex,entityTable)

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
@@ -58,7 +58,7 @@ class FSP3000R7OTU100GMib(FSP3000R7MibCommon):
         # cached data from device modeler
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsOPRModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
             containsOPRModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.15.0"
+VERSION = "1.16.0"
 AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']


### PR DESCRIPTION
# Problem
The recent 1.15 update included a filter to skip components during modeling if they had an administrative status other than "In Service", "Auto In Service", or "Undefined". This filtered out more components than expected.
# Solution
Revert the three commits related to administrative state, restoring a few minor code cleanups that got mixed in with them.
# Testing
Merit Network Engineering has re-tested and approved this change in our development environment.