### PR TITLE
SDQ 2072: Add default low-level threshold to 100 Gig Optical components

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,7 @@ Change History
 
 * 1.16
 
-  * Removed checks for adminState when determining "in production" components
+  * Removed checks for AdminState
 
 * 1.17
 

--- a/README.rst
+++ b/README.rst
@@ -213,15 +213,29 @@ Change History
 * 1.15
 
   * Added support for more 100 Gig hardware
+
   * Added checks for AdminState to ignore out-of-service components
+
   * Changed component modeling for OTU ports to continue search after first port on a card
+
   * Added new data/graphs:
+
     * Added Rx, Tx, and SNR to OTU100Gig
+
     * Added Rx to Optical100Gig
+
     * Added SNR, FEC to Transponders
 
+* 1.16
+
+  * Removed checks for adminState when determining "in production" components
+
+* 1.17
+
+  * Added default low-level threshold to 100 Gig Optical components
+
 Known Issues
-===========
+============
 
 * Component templates attempt to graph data that may not be available from
   some components.  This may result in debug level events for SNMP variables

--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,7 @@ Change History
     * Added Rx, Tx, and SNR to OTU100Gig
 
     * Added Rx to Optical100Gig
-Sdq 2072 add low threshold 100g optical
+
     * Added SNR, FEC to Transponders
 
 * 1.16

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.17"
+VERSION = "1.17.0"
 AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.16"
+VERSION = "1.17"
 AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.15.0"
+VERSION = "1.16"
 AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']


### PR DESCRIPTION
# Problem

After a recent ZenPack update to add input power graphs/data to 100 Gig Optical components, a corresponding threshold wasn't applied to generate Zenoss events when input power dropped.

# Solution

Copy the existing threshold from the "Transponder" component class into the "100G Muxsponder Optical" class. This will apply a default threshold of -270 (equivalent to -27.0 dBm) to these components.

# Testing

This has been tested by Merit Network Engineering and Software Development.