### PR TITLE
Update fan and PSU model strings

### DIFF
--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FanModels.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FanModels.py
@@ -8,4 +8,4 @@
 
 __doc__='Valid Fan component models'
 
-FanModels = [ 'FAN/9HU','FAN/PLUG-IN', 'FAN/Plug-In', 'FAN/1HU', 'FTM-4' ]
+FanModels = [ 'FAN/9HU','FAN/PLUG-IN', 'FAN/Plug-In', 'FAN/1HU', 'FTM-3', 'FTM-4', 'F8/FTM-4', 'CEM-4' ]

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/PowerSupplyModels.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/PowerSupplyModels.py
@@ -12,4 +12,4 @@ PowerSupplyModels = [ 'PSU/7HU-DC',   'PSU/7HU-AC',   'PSU/7HU-R-DC',
                       'PSU/9HU-DC',   'PSU/9HU-AC',   'PSU/1HU-R-AC',
                       'PSU/7HU-AC-800', 'PSU/7HU-DC-800', 'PSU/7HU-R-DC-HP',
                       'PSU/1HU-R-AC-200', 'PSU/1HU-R-DC-200',
-                      'PSU/X9HU-DC-800', 'PSM-AC4', 'PSM-AC5', 'PSM-DC4' ]
+                      'PSU/X9HU-DC-800', 'PSM-AC3', 'PSM-AC4', 'PSM-AC5', 'PSM-DC4' ]


### PR DESCRIPTION
# Summary
Network Engineering noticed that some of the newer fan and power supply modules weren't being sorted into the appropriate categories. The model strings for these are enumerated in the ZenPack; I looked into using the EntityClass attribute to avoid updating every time we encounter new models, but sometimes the components just have a generic "module" or "plug" class instead of "fan" or "powerSupply".