### PR TITLE
ZEN-16: Refactor OTL modeler to filter by entity class, not regex

### DIFF
--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7Optical100GigMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7Optical100GigMib.py
@@ -4,49 +4,60 @@
 #
 ######################################################################
 
-__doc__="""Walk the OID for entityFacilityAidString and detect 100Gig
-Muxponder optical side entities on network ports matching strings like
-OTL-1-1-N-3."""
+__doc__="""Check the FSP3000R7 SNMP cache for optical lane (OTL) entities"""
 
-from pprint import pformat
-import re
-
-from Products.DataCollector.plugins.CollectorPlugin \
-    import SnmpPlugin, GetTableMap, GetMap
+from Products.DataCollector.plugins.CollectorPlugin import GetMap
+from Products.DataCollector.plugins.CollectorPlugin import SnmpPlugin
+from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibPickle import getCache
+from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import EntityClass
 
 class FSP3000R7Optical100GigMib(SnmpPlugin):
 
     modname = "ZenPacks.Merit.AdvaFSP3000R7.FSP3000R7Optical100Gig"
     relname = "FSP3000R7Optical100G"
 
-    # The inventory table used by the other components does not include
-    # the components this plugin is looking for.  Need to look at
-    # entityFacilityAidString in entityFacilityTable for these
+    allowed_entity_classes = [
+        EntityClass.OPT_CHANNEL_TRANSPORT_LANE,
+    ]
 
-    snmpGetTableMaps = [GetTableMap('entityFacilityTable',
-                                   '.1.3.6.1.4.1.2544.1.11.7.2.7.1',
-                                   { '.6' : 'entityFacilityAidString' } )]
+    # Not actually used; just have to get something with SNMP or modeler won't process
+    snmpGetMap = GetMap({'.1.3.6.1.4.1.2544.1.11.2.2.1.1.0' : 'setHWTag'})
 
     def process(self, device, results, log):
         """process snmp information for components from this device"""
         log.info('processing %s for device %s', self.name(), device.id)
 
+        # tabledata is not actually used (instead, use cached SNMP data file created in FSP3000R7Device modeler)
+        getdata = {}
+        getdata['setHWTag'] = False
         getdata, tabledata = results
+        if not getdata['setHWTag']:
+            log.info("Couldn't get system name from Adva shelf.")
 
-        log.debug('got results: %s', pformat(tabledata))
+        cache = getCache(device.id, self.name(), log)
+        if not cache:
+            log.error('Could not get cache for %s' % self.name())
+            return
 
         # relationship mapping
         rm = self.relMap()
 
-        for snmpIndex in tabledata['entityFacilityTable']:
-            entityFacilityAidString = tabledata['entityFacilityTable']\
-                                          [snmpIndex]['entityFacilityAidString']
-            if re.match('OTL\-\d+\-\d+\-N\-\d$',entityFacilityAidString) or re.match('OTL-\d+-\d+-C\d-\d$',entityFacilityAidString) :
-                om = self.objectMap()
-                om.title = entityFacilityAidString
-                om.id = self.prepId(entityFacilityAidString)
-                om.snmpindex = snmpIndex
+        for index, attrs in cache['facilityTable'].items():
+            aid_string = attrs.get('entityFacilityAidString', '')
+            facility_class = attrs.get('entityFacilityClass', '')
+            unit_name = attrs.get('inventoryUnitName', '')
 
-                rm.append(om)
+            if facility_class not in self.allowed_entity_classes:
+                log.debug('Skipping non-optical transport component %s' % aid_string)
+                continue
+
+            om = self.objectMap()
+            om.title = aid_string
+            om.id = self.prepId(aid_string)
+            om.inventoryUnitName = unit_name
+            om.snmpindex = index
+
+            log.info("Found optical transport lane %s", aid_string)
+            rm.append(om)
 
         return rm


### PR DESCRIPTION
# Summary
Network Engineering noted that some newer OTL components weren't being picked up in Zenoss; this was because of an overly-restrictive regex. Instead, we can replace most of the code with the same filtering and data from the Virtual Channel modelers which use the EntityClass attribute instead.